### PR TITLE
Updated git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This section provides a quick guide to experience Wi-Fi functionality. For instr
 
 2. Download bl_iot_sdk
   ```bash
-  git clone --recursive git@github.com:bouffalolab/bl_iot_sdk.git
+  git clone --recursive https://github.com/bouffalolab/bl_iot_sdk.git
   ```
 
 3. Build M0 and D0 firmwares


### PR DESCRIPTION
The original git clone command gave an error "Permission Denied" when not authenticated with a Github account with your public key, using the HTTPS version of the link instead fixes this for anonymous downloads.